### PR TITLE
Enable code coverage for MobiusNimble.xcscheme

### DIFF
--- a/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusNimble.xcscheme
+++ b/Mobius.xcodeproj/xcshareddata/xcschemes/MobiusNimble.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
We've regularly run into issues with Carthage failing to build the `MobiusNimble` scheme and every time it's been fixed by enabling code coverage. This is the only scheme without it enabled, so I'm not sure if that was an oversight or done for a reason.